### PR TITLE
Perf: Cache XmlSerializer as static field per generic type

### DIFF
--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
@@ -35,7 +35,7 @@ public sealed class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, Xm
 {
     private static readonly string OperationName = $"XML multi-stream extraction of {typeof(TRecord).Name}";
     private readonly IEnumerable<Stream> _streams;
-    private readonly XmlSerializer _serializer;
+    private static readonly XmlSerializer Serializer = new(typeof(TRecord));
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
@@ -58,7 +58,7 @@ public sealed class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, Xm
     {
         _streams = streams ?? throw new ArgumentNullException(nameof(streams));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _serializer = new XmlSerializer(typeof(TRecord));
+
     }
 
 
@@ -80,7 +80,7 @@ public sealed class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, Xm
         _streams = streams ?? throw new ArgumentNullException(nameof(streams));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
-        _serializer = new XmlSerializer(typeof(TRecord));
+
     }
 
 
@@ -106,7 +106,7 @@ public sealed class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, Xm
             TRecord? item;
             try
             {
-                item = (TRecord?)_serializer.Deserialize(stream);
+                item = (TRecord?)Serializer.Deserialize(stream);
             }
             finally
             {

--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
@@ -37,7 +37,7 @@ public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepor
     private static readonly string OperationName = $"XML multi-stream loading of {typeof(TRecord).Name}";
     private readonly Func<TRecord, Stream> _streamFactory;
     private readonly XmlWriterSettings? _writerSettings;
-    private readonly XmlSerializer _serializer;
+    private static readonly XmlSerializer Serializer = new(typeof(TRecord));
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
@@ -64,7 +64,7 @@ public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepor
         _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _writerSettings = null;
-        _serializer = new XmlSerializer(typeof(TRecord));
+
     }
 
 
@@ -92,7 +92,7 @@ public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepor
         _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
         _writerSettings = writerSettings ?? throw new ArgumentNullException(nameof(writerSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _serializer = new XmlSerializer(typeof(TRecord));
+
     }
 
 
@@ -119,7 +119,7 @@ public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepor
         _writerSettings = writerSettings ?? throw new ArgumentNullException(nameof(writerSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
-        _serializer = new XmlSerializer(typeof(TRecord));
+
     }
 
 
@@ -161,7 +161,7 @@ public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepor
 
             try
             {
-                _serializer.Serialize(stream, item);
+                Serializer.Serialize(stream, item);
 #if NETSTANDARD2_0 || NET462 || NET481
 #pragma warning disable CA2016, MA0040 // FlushAsync(CancellationToken) not available on this TFM
                 await stream.FlushAsync().ConfigureAwait(false);

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
@@ -37,7 +37,7 @@ public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, X
 {
     private readonly Stream _stream;
     private readonly XmlReaderSettings? _readerSettings;
-    private readonly XmlSerializer _serializer;
+    private static readonly XmlSerializer Serializer = new(typeof(TRecord));
     private readonly ILogger _logger;
     private static readonly string OperationName = $"XML single-stream extraction of {typeof(TRecord).Name}";
     private readonly IProgressTimer? _progressTimer;
@@ -62,7 +62,6 @@ public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, X
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _readerSettings = null;
-        _serializer = new XmlSerializer(typeof(TRecord));
     }
 
 
@@ -87,7 +86,6 @@ public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, X
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _readerSettings = readerSettings ?? throw new ArgumentNullException(nameof(readerSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _serializer = new XmlSerializer(typeof(TRecord));
     }
 
 
@@ -112,7 +110,6 @@ public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, X
         _readerSettings = readerSettings ?? throw new ArgumentNullException(nameof(readerSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
-        _serializer = new XmlSerializer(typeof(TRecord));
     }
 
 
@@ -204,7 +201,7 @@ public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, X
             return default;
         }
 
-        var item = (TRecord?)_serializer.Deserialize(reader);
+        var item = (TRecord?)Serializer.Deserialize(reader);
         if (item is null)
         {
             XmlLogMessages.SkippingNullElement(_logger, null);

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
@@ -36,7 +36,7 @@ public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepo
 
     private readonly Stream _stream;
     private readonly XmlWriterSettings? _writerSettings;
-    private readonly XmlSerializer _serializer;
+    private static readonly XmlSerializer Serializer = new(typeof(TRecord));
     private readonly string _rootElementName;
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
@@ -61,7 +61,7 @@ public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepo
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _writerSettings = null;
-        _serializer = new XmlSerializer(typeof(TRecord));
+
         _rootElementName = "ArrayOf" + typeof(TRecord).Name;
     }
 
@@ -87,7 +87,7 @@ public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepo
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _writerSettings = writerSettings ?? throw new ArgumentNullException(nameof(writerSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _serializer = new XmlSerializer(typeof(TRecord));
+
         _rootElementName = "ArrayOf" + typeof(TRecord).Name;
     }
 
@@ -113,7 +113,7 @@ public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepo
         _writerSettings = writerSettings ?? throw new ArgumentNullException(nameof(writerSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
-        _serializer = new XmlSerializer(typeof(TRecord));
+
         _rootElementName = "ArrayOf" + typeof(TRecord).Name;
     }
 
@@ -154,7 +154,7 @@ public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepo
                 break;
             }
 
-            _serializer.Serialize(writer, item, EmptyNamespaces);
+            Serializer.Serialize(writer, item, EmptyNamespaces);
             IncrementCurrentItemCount();
 
             XmlLogMessages.LoadedItem(_logger, CurrentItemCount, null);


### PR DESCRIPTION
## Summary

- `XmlSerializer` construction is expensive (generates IL assemblies at runtime)
- Changed from per-instance field to `private static readonly` per generic type
- `XmlSerializer` instances are thread-safe for `Serialize`/`Deserialize` after construction

## Affected files
- `XmlSingleStreamExtractor.cs`
- `XmlSingleStreamLoader.cs`
- `XmlMultiStreamExtractor.cs`
- `XmlMultiStreamLoader.cs`

## Test plan
- [x] Build succeeds across all TFMs
- [ ] Verify tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)