### PR TITLE
Perf: Cache log operation name strings as static fields

### DIFF
--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
@@ -33,6 +33,7 @@ namespace Wolfgang.Etl.Xml;
 public class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
+    private static readonly string OperationName = $"XML multi-stream extraction of {typeof(TRecord).Name}";
     private readonly IEnumerable<Stream> _streams;
     private readonly XmlSerializer _serializer;
     private readonly ILogger _logger;
@@ -92,7 +93,7 @@ public class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlReport
     )
 #pragma warning restore CS1998
     {
-        XmlLogMessages.StartingOperation(_logger, $"XML multi-stream extraction of {typeof(TRecord).Name}", null);
+        XmlLogMessages.StartingOperation(_logger, OperationName, null);
 
         var skipBudget = SkipItemCount;
         var streamIndex = 0;

--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
@@ -34,6 +34,7 @@ namespace Wolfgang.Etl.Xml;
 public class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
+    private static readonly string OperationName = $"XML multi-stream loading of {typeof(TRecord).Name}";
     private readonly Func<TRecord, Stream> _streamFactory;
     private readonly XmlWriterSettings? _writerSettings;
     private readonly XmlSerializer _serializer;
@@ -130,7 +131,7 @@ public class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
         CancellationToken token
     )
     {
-        XmlLogMessages.StartingOperation(_logger, $"XML multi-stream loading of {typeof(TRecord).Name}", null);
+        XmlLogMessages.StartingOperation(_logger, OperationName, null);
 
         var streamIndex = 0;
 

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
@@ -39,6 +39,7 @@ public class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlRepor
     private readonly XmlReaderSettings? _readerSettings;
     private readonly XmlSerializer _serializer;
     private readonly ILogger _logger;
+    private static readonly string OperationName = $"XML single-stream extraction of {typeof(TRecord).Name}";
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
 
@@ -122,7 +123,7 @@ public class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlRepor
         [EnumeratorCancellation] CancellationToken token
     )
     {
-        XmlLogMessages.StartingOperation(_logger, $"XML single-stream extraction of {typeof(TRecord).Name}", null);
+        XmlLogMessages.StartingOperation(_logger, OperationName, null);
 
         var skipBudget = SkipItemCount;
         var settings = _readerSettings ?? new XmlReaderSettings();

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
@@ -30,6 +30,7 @@ namespace Wolfgang.Etl.Xml;
 public class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
+    private static readonly string OperationName = $"XML single-stream loading of {typeof(TRecord).Name}";
     private static readonly XmlSerializerNamespaces EmptyNamespaces =
         new(new[] { new XmlQualifiedName(name: "", ns: "") });
 
@@ -125,7 +126,7 @@ public class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
         CancellationToken token
     )
     {
-        XmlLogMessages.StartingOperation(_logger, $"XML single-stream loading of {typeof(TRecord).Name}", null);
+        XmlLogMessages.StartingOperation(_logger, OperationName, null);
 
         var settings = _writerSettings ?? new XmlWriterSettings { Indent = true };
         settings.CloseOutput = false;


### PR DESCRIPTION
## Summary

- String interpolation like `$"XML single-stream extraction of {typeof(TRecord).Name}"` allocated a new string on every call to `ExtractWorkerAsync`/`LoadWorkerAsync`
- Since `typeof(TRecord).Name` is constant per generic instantiation, cached as `private static readonly string OperationName`

## Affected files
- `XmlSingleStreamExtractor.cs`
- `XmlSingleStreamLoader.cs`
- `XmlMultiStreamExtractor.cs`
- `XmlMultiStreamLoader.cs`

## Test plan
- [x] Build succeeds across all TFMs
- [ ] Verify tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)