### PR TITLE
Perf: Seal extractor and loader classes

### DIFF
--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
@@ -30,7 +30,7 @@ namespace Wolfgang.Etl.Xml;
 /// }
 /// </code>
 /// </example>
-public class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlReport>
+public sealed class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
     private readonly IEnumerable<Stream> _streams;

--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
@@ -31,7 +31,7 @@ namespace Wolfgang.Etl.Xml;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
+public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
     private readonly Func<TRecord, Stream> _streamFactory;

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
@@ -32,7 +32,7 @@ namespace Wolfgang.Etl.Xml;
 /// }
 /// </code>
 /// </example>
-public class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlReport>
+public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
     private readonly Stream _stream;

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
@@ -27,7 +27,7 @@ namespace Wolfgang.Etl.Xml;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
+public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlReport>
     where TRecord : notnull, new()
 {
     private static readonly XmlSerializerNamespaces EmptyNamespaces =


### PR DESCRIPTION
## Summary

- Sealed all 4 extractor/loader classes (`XmlSingleStreamExtractor`, `XmlSingleStreamLoader`, `XmlMultiStreamExtractor`, `XmlMultiStreamLoader`)
- These are not designed for inheritance — users inherit from `ExtractorBase`/`LoaderBase` directly
- Sealing allows the JIT to devirtualize method calls and skip virtual dispatch

## Test plan
- [x] Build succeeds across all TFMs
- [ ] Verify tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)