### PR TITLE
Perf: Remove redundant CanDeserialize check

### DIFF
--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
@@ -203,12 +203,6 @@ public class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, XmlRepor
             return default;
         }
 
-        if (!_serializer.CanDeserialize(reader))
-        {
-            XmlLogMessages.SkippingNullElement(_logger, null);
-            return default;
-        }
-
         var item = (TRecord?)_serializer.Deserialize(reader);
         if (item is null)
         {


### PR DESCRIPTION
## Summary

- Removed `CanDeserialize(reader)` call before `Deserialize(reader)` in `XmlSingleStreamExtractor`
- `CanDeserialize` reads the element name a second time unnecessarily
- We already filter for `Element` nodes at `Depth == 1`, and `Deserialize` returns null for unrecognized elements (which is already handled)

## Test plan
- [x] Build succeeds across all TFMs
- [ ] Verify tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)