### PR TITLE
Prepare for initial release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,13 +43,13 @@
     </PackageReference>
     
     <!-- NEW: Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.7">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
     <!-- NEW: SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/README.md
+++ b/README.md
@@ -8,23 +8,21 @@ Extractors and loaders for working with XML files using the Wolfgang.Etl design 
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 dotnet add package Wolfgang.Etl.Xml
 ```
 
-**NuGet Package:** Coming soon to NuGet.org
-
 ---
 
-## 📄 License
+## License
 
 This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) file for details.
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 - **GitHub Repository:** [https://github.com/Chris-Wolfgang/ETL-Xml](https://github.com/Chris-Wolfgang/ETL-Xml)
 - **API Documentation:** https://Chris-Wolfgang.github.io/ETL-Xml/
@@ -33,32 +31,113 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
-{{QUICK_START_EXAMPLE}}
+Extract items from an XML stream through a full ETL pipeline:
+
+```csharp
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.Xml;
+
+// Extract from XML → Transform → Load into memory
+var extractor = new XmlSingleStreamExtractor<Person>
+(
+    xmlStream,
+    logger
+);
+
+var transformer = new TestTransformer<Person>();
+var loader = new TestLoader<Person>(collectItems: true);
+
+await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+
+var items = loader.GetCollectedItems();
+```
+
+Load items to an XML stream from an in-memory source:
+
+```csharp
+// Extract from memory → Transform → Load to XML
+var extractor = new TestExtractor<Person>(people);
+var transformer = new TestTransformer<Person>();
+
+var loader = new XmlSingleStreamLoader<Person>
+(
+    outputStream,
+    logger
+);
+
+await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+```
 
 ---
 
-## ✨ Features
+## Features
 
-{{FEATURES_TABLE}}
+| Feature | Description |
+|---------|-------------|
+| Single-stream XML | Read/write multiple items from/to a single XML document with a root element wrapper |
+| Multi-stream XML | Read/write one item per XML stream (one file per record) |
+| Streaming deserialization | Uses `XmlReader` for memory-efficient forward-only parsing |
+| Progress reporting | Built-in `IProgress<XmlReport>` support with configurable reporting intervals |
+| Skip and maximum | `SkipItemCount` and `MaximumItemCount` for paging through large XML sources |
+| Custom XML settings | Accept `XmlReaderSettings` and `XmlWriterSettings` for full control over XML behavior |
+| Structured logging | High-performance `LoggerMessage`-based logging with categorized event IDs |
+| Multi-TFM | Targets .NET Framework 4.6.2+, .NET Standard 2.0, .NET 8.0, and .NET 10.0 |
 
-**Examples:**
-{{FEATURE_EXAMPLES}}
+### Extractors
+
+- **`XmlSingleStreamExtractor<T>`** — Extracts items from a single XML stream containing a root element with child elements (e.g. `<ArrayOfPerson><Person/>...</ArrayOfPerson>`).
+- **`XmlMultiStreamExtractor<T>`** — Extracts items from multiple XML streams, one document per stream.
+
+### Loaders
+
+- **`XmlSingleStreamLoader<T>`** — Loads items into a single XML stream wrapped in a root element.
+- **`XmlMultiStreamLoader<T>`** — Loads items into multiple XML streams via a factory function, one document per stream.
+
+### Progress reporting
+
+```csharp
+var extractor = new XmlSingleStreamExtractor<Person>(xmlStream, logger);
+extractor.ReportingInterval = 100; // Report every 100ms
+
+var progress = new Progress<XmlReport>(report =>
+    Console.WriteLine($"Progress: {report.CurrentItemCount} items, {report.CurrentSkippedItemCount} skipped")
+);
+
+var transformer = new TestTransformer<Person>();
+var loader = new TestLoader<Person>(collectItems: true);
+
+await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync(progress)));
+```
+
+### Skip and maximum item count
+
+```csharp
+var extractor = new XmlSingleStreamExtractor<Person>(xmlStream, logger);
+extractor.SkipItemCount = 10;     // Skip first 10 items
+extractor.MaximumItemCount = 5;   // Then take 5 items
+
+var transformer = new TestTransformer<Person>();
+var loader = new TestLoader<Person>(collectItems: true);
+
+await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+// extractor.CurrentItemCount == 5, extractor.CurrentSkippedItemCount == 10
+```
 
 ---
 
-## 🎯 Target Frameworks
+## Target Frameworks
 
-| Framework | Versions |
-|-----------|----------|
-| .Net Framework | .net 4.6.2, .net 4.7.0, .net 4.7.1, .net 4.7.2, .net 4.8, .net 4.8.1 | 
-| .Net Core | |
-| .Net | .net 5.0, .net 6.0, .net 7.0, .net 8.0, .net 9.0, .net 10.0 |
+| Platform | Versions |
+|----------|----------|
+| .NET Framework | 4.6.2, 4.8.1 |
+| .NET Standard | 2.0 |
+| .NET | 8.0, 10.0 |
 
 ---
 
-## 🔍 Code Quality & Static Analysis
+## Code Quality & Static Analysis
 
 This project enforces **strict code quality standards** through **7 specialized analyzers** and custom async-first rules:
 
@@ -77,18 +156,16 @@ This project enforces **strict code quality standards** through **7 specialized 
 This library uses **`BannedSymbols.txt`** to prohibit synchronous APIs and enforce async-first patterns:
 
 **Blocked APIs Include:**
-- ❌ `Task.Wait()`, `Task.Result` - Use `await` instead
-- ❌ `Thread.Sleep()` - Use `await Task.Delay()` instead
-- ❌ Synchronous file I/O (`File.ReadAllText`) - Use async versions
-- ❌ Synchronous stream operations - Use `ReadAsync()`, `WriteAsync()`
-- ❌ `Parallel.For/ForEach` - Use `Task.WhenAll()` or `Parallel.ForEachAsync()`
-- ❌ Obsolete APIs (`WebClient`, `BinaryFormatter`)
-
-**Why?** To ensure all code is **truly async** and **non-blocking** for optimal performance in async contexts.
+- `Task.Wait()`, `Task.Result` - Use `await` instead
+- `Thread.Sleep()` - Use `await Task.Delay()` instead
+- Synchronous file I/O (`File.ReadAllText`) - Use async versions
+- Synchronous stream operations - Use `ReadAsync()`, `WriteAsync()`
+- `Parallel.For/ForEach` - Use `Task.WhenAll()` or `Parallel.ForEachAsync()`
+- Obsolete APIs (`WebClient`, `BinaryFormatter`)
 
 ---
 
-## 🛠️ Building from Source
+## Building from Source
 
 ### Prerequisites
 - [.NET 8.0 SDK](https://dotnet.microsoft.com/download) or later
@@ -164,7 +241,7 @@ docfx build --serve
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
 - Code quality standards
@@ -174,8 +251,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ---
 
+## Acknowledgments
 
-## 🙏 Acknowledgments
-
-{{ACKNOWLEDGMENTS}}
-
+- [Wolfgang.Etl.Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions) — the base class framework this library builds on
+- [Wolfgang.Etl.TestKit](https://github.com/Chris-Wolfgang/ETL-Test-Kit) — test doubles and contract test base classes for pipeline development

--- a/benchmarks/Wolfgang.Etl.Xml.Benchmarks/Wolfgang.Etl.Xml.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.Xml.Benchmarks/Wolfgang.Etl.Xml.Benchmarks.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
 </Project>

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -4,14 +4,12 @@ This guide will help you quickly get up and running with Wolfgang.Etl.Xml.
 
 ## Prerequisites
 
-<!-- List any prerequisites needed. For example:
-- .NET 8.0 or later
-- Visual Studio 2022 or Visual Studio Code
--->
+- .NET 8.0 SDK or later (also supports .NET Framework 4.6.2+ and .NET Standard 2.0)
+- A logging provider (e.g. `Microsoft.Extensions.Logging`)
 
 ## Installation
 
-### Via NuGet Package Manager
+### Via .NET CLI
 
 ```bash
 dotnet add package Wolfgang.Etl.Xml
@@ -25,26 +23,78 @@ Install-Package Wolfgang.Etl.Xml
 
 ## Quick Start
 
-<!-- Add a quick start example. For example: -->
+### Extracting from XML
+
+Read items from an XML stream and pipe them through a transformer into a loader:
 
 ```csharp
-// Add your quick start code example here
-// This should show the simplest way to use your library
-
+using Wolfgang.Etl.TestKit;
 using Wolfgang.Etl.Xml;
 
-// Example usage
+// XmlSingleStreamExtractor reads items from a single XML document
+var extractor = new XmlSingleStreamExtractor<Person>
+(
+    xmlStream,
+    logger
+);
+
+// Use TestKit placeholders for the rest of the pipeline
+var transformer = new TestTransformer<Person>();
+var loader = new TestLoader<Person>(collectItems: true);
+
+await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+
+var items = loader.GetCollectedItems();
+```
+
+### Loading to XML
+
+Pipe items from any source through a transformer and write them to an XML stream:
+
+```csharp
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.Xml;
+
+// Use TestKit as the data source
+var extractor = new TestExtractor<Person>(people);
+var transformer = new TestTransformer<Person>();
+
+// XmlSingleStreamLoader writes items to a single XML document
+var loader = new XmlSingleStreamLoader<Person>
+(
+    outputStream,
+    new XmlWriterSettings { Indent = true },
+    logger
+);
+
+await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+```
+
+### Multi-stream (one item per file)
+
+For scenarios where each record lives in its own XML file:
+
+```csharp
+// Extract from multiple XML files
+var extractor = new XmlMultiStreamExtractor<Person>
+(
+    xmlStreams,
+    logger
+);
+
+// Load to individual XML files via a stream factory
+var loader = new XmlMultiStreamLoader<Person>
+(
+    person => File.Create($"{person.Id}.xml"),
+    logger
+);
 ```
 
 ## Next Steps
 
 - Explore the [API Reference](../api/index.md) for detailed documentation
 - Read the [Introduction](introduction.md) to learn more about Wolfgang.Etl.Xml
-- Check out example projects in the [GitHub repository](https://github.com/Chris-Wolfgang/ETL-Xml)
-
-## Common Issues
-
-<!-- Add common issues and their solutions here -->
+- Check out [example projects](https://github.com/Chris-Wolfgang/ETL-Xml/tree/main/examples) in the GitHub repository
 
 ## Additional Resources
 

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -1,20 +1,24 @@
 # Introduction
 
-Welcome to Wolfgang.Etl.Xml!
+Wolfgang.Etl.Xml provides extractors and loaders for reading and writing XML files, built on [Wolfgang.Etl.Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions).
 
 ## Overview
 
-Extractors and loaders for working with XML files using the Wolfgang.Etl design pattern
+This library implements the Extract-Transform-Load (ETL) pattern for XML data. It provides four components that plug into any Wolfgang.Etl pipeline:
 
-<!-- Add your project overview here -->
+- **XmlSingleStreamExtractor&lt;T&gt;** — Reads multiple items from a single XML document with a root element wrapper (e.g. `<ArrayOfPerson><Person/>...</ArrayOfPerson>`).
+- **XmlSingleStreamLoader&lt;T&gt;** — Writes multiple items into a single XML document with a root element wrapper.
+- **XmlMultiStreamExtractor&lt;T&gt;** — Reads items from multiple XML streams, one document per stream.
+- **XmlMultiStreamLoader&lt;T&gt;** — Writes items to multiple XML streams via a factory function, one document per stream.
 
 ## Key Features
 
-<!-- List the main features of your project. For example:
-- Feature 1: Description
-- Feature 2: Description
-- Feature 3: Description
--->
+- **Streaming deserialization** — Uses `XmlReader` for memory-efficient forward-only parsing of large XML files.
+- **Progress reporting** — Built-in `IProgress<XmlReport>` support with configurable reporting intervals.
+- **Skip and maximum** — `SkipItemCount` and `MaximumItemCount` properties for paging through large XML sources.
+- **Custom XML settings** — Accepts `XmlReaderSettings` and `XmlWriterSettings` for full control over XML behavior.
+- **Structured logging** — High-performance `LoggerMessage`-based logging with categorized event IDs.
+- **Multi-TFM support** — Targets .NET Framework 4.6.2+, .NET Standard 2.0, .NET 8.0, and .NET 10.0.
 
 ## Getting Help
 

--- a/examples/Wolfgang.Etl.Xml.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Xml.Examples/Program.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Xml.Serialization;
 using Microsoft.Extensions.Logging;
+using Wolfgang.Etl.TestKit;
 using Wolfgang.Etl.Xml;
 using Wolfgang.Etl.Xml.Examples;
 
@@ -15,58 +16,48 @@ using var loggerFactory = LoggerFactory.Create(builder =>
     builder.SetMinimumLevel(LogLevel.Debug);
 });
 
-await SingleStreamExample(loggerFactory);
+await SingleStreamExtractPipeline(loggerFactory);
 Console.WriteLine();
-await MultiStreamExample(loggerFactory);
+await SingleStreamLoadPipeline(loggerFactory);
 Console.WriteLine();
-await ProgressReportingExample(loggerFactory);
+await MultiStreamExtractPipeline(loggerFactory);
 Console.WriteLine();
-await SkipAndMaxExample(loggerFactory);
+await MultiStreamLoadPipeline(loggerFactory);
 
 
 
-static async Task SingleStreamExample(ILoggerFactory loggerFactory)
+/// <summary>
+/// Demonstrates extracting from XML through a full ETL pipeline.
+/// XmlSingleStreamExtractor reads from an XML stream, then a
+/// TestTransformer passes items through, and a TestLoader collects them.
+/// </summary>
+static async Task SingleStreamExtractPipeline(ILoggerFactory loggerFactory)
 {
-    Console.WriteLine("=== Single Stream Example ===");
+    Console.WriteLine("=== Single-Stream Extract Pipeline ===");
     Console.WriteLine();
 
-    // Create sample data
-    var people = new List<Person>
-    {
-        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
-        new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
-        new() { FirstName = "Carol", LastName = "White", Age = 35, Email = "carol@example.com" },
-    };
+    // Prepare sample XML data
+    var xmlStream = CreateSampleXmlStream();
 
-    // --- Load to XML ---
-    var stream = new MemoryStream();
-    var loader = new XmlSingleStreamLoader<Person>
-    (
-        stream,
-        loggerFactory.CreateLogger<XmlSingleStreamLoader<Person>>()
-    );
-
-    await loader.LoadAsync(people.ToAsyncEnumerable());
-    Console.WriteLine($"Loaded {loader.CurrentItemCount} items to XML stream.");
-
-    // Show the XML
-    stream.Position = 0;
-    using var reader = new StreamReader(stream);
-    var xml = await reader.ReadToEndAsync();
-    Console.WriteLine();
-    Console.WriteLine("Generated XML:");
-    Console.WriteLine(xml);
-
-    // --- Extract from XML ---
-    stream.Position = 0;
+    // --- Extract → Transform → Load pipeline ---
     var extractor = new XmlSingleStreamExtractor<Person>
     (
-        stream,
+        xmlStream,
         loggerFactory.CreateLogger<XmlSingleStreamExtractor<Person>>()
     );
 
-    Console.WriteLine("Extracted items:");
-    await foreach (var person in extractor.ExtractAsync())
+    var transformer = new TestTransformer<Person>();
+    var loader = new TestLoader<Person>(collectItems: true);
+
+    await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+
+    // Show results
+    Console.WriteLine($"Extracted {extractor.CurrentItemCount} items from XML.");
+    Console.WriteLine($"Transformed {transformer.CurrentItemCount} items.");
+    Console.WriteLine($"Loaded {loader.CurrentItemCount} items.");
+    Console.WriteLine();
+
+    foreach (var person in loader.GetCollectedItems()!)
     {
         Console.WriteLine($"  {person.FirstName} {person.LastName}, age {person.Age}");
     }
@@ -74,18 +65,106 @@ static async Task SingleStreamExample(ILoggerFactory loggerFactory)
 
 
 
-static async Task MultiStreamExample(ILoggerFactory loggerFactory)
+/// <summary>
+/// Demonstrates loading to XML through a full ETL pipeline.
+/// TestExtractor provides in-memory data, TestTransformer passes it
+/// through, and XmlSingleStreamLoader writes the XML output.
+/// </summary>
+static async Task SingleStreamLoadPipeline(ILoggerFactory loggerFactory)
 {
-    Console.WriteLine("=== Multi-Stream Example ===");
+    Console.WriteLine("=== Single-Stream Load Pipeline ===");
     Console.WriteLine();
 
+    // --- Extract → Transform → Load pipeline ---
+    var people = new List<Person>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
+        new() { FirstName = "Carol", LastName = "White", Age = 35, Email = "carol@example.com" },
+    };
+
+    var extractor = new TestExtractor<Person>(people);
+    var transformer = new TestTransformer<Person>();
+
+    var outputStream = new MemoryStream();
+    var loader = new XmlSingleStreamLoader<Person>
+    (
+        outputStream,
+        new XmlWriterSettings { Indent = true },
+        loggerFactory.CreateLogger<XmlSingleStreamLoader<Person>>()
+    );
+
+    await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+
+    // Show resulting XML
+    Console.WriteLine($"Extracted {extractor.CurrentItemCount} items from memory.");
+    Console.WriteLine($"Transformed {transformer.CurrentItemCount} items.");
+    Console.WriteLine($"Loaded {loader.CurrentItemCount} items to XML.");
+    Console.WriteLine();
+
+    outputStream.Position = 0;
+    using var reader = new StreamReader(outputStream);
+    Console.WriteLine(await reader.ReadToEndAsync());
+}
+
+
+
+/// <summary>
+/// Demonstrates extracting from multiple XML streams (one item per file)
+/// through a full ETL pipeline using TestTransformer and TestLoader.
+/// </summary>
+static async Task MultiStreamExtractPipeline(ILoggerFactory loggerFactory)
+{
+    Console.WriteLine("=== Multi-Stream Extract Pipeline ===");
+    Console.WriteLine();
+
+    // Prepare individual XML streams (simulating one-item-per-file)
+    var streams = CreateSampleMultiStreams();
+
+    // --- Extract → Transform → Load pipeline ---
+    var extractor = new XmlMultiStreamExtractor<Person>
+    (
+        streams,
+        loggerFactory.CreateLogger<XmlMultiStreamExtractor<Person>>()
+    );
+
+    var transformer = new TestTransformer<Person>();
+    var loader = new TestLoader<Person>(collectItems: true);
+
+    await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
+
+    Console.WriteLine($"Extracted {extractor.CurrentItemCount} items from {streams.Count} streams.");
+    Console.WriteLine($"Transformed {transformer.CurrentItemCount} items.");
+    Console.WriteLine($"Loaded {loader.CurrentItemCount} items.");
+    Console.WriteLine();
+
+    foreach (var person in loader.GetCollectedItems()!)
+    {
+        Console.WriteLine($"  {person.FirstName} {person.LastName}, age {person.Age}");
+    }
+}
+
+
+
+/// <summary>
+/// Demonstrates loading to multiple XML streams (one item per file)
+/// through a full ETL pipeline using TestExtractor and TestTransformer.
+/// </summary>
+static async Task MultiStreamLoadPipeline(ILoggerFactory loggerFactory)
+{
+    Console.WriteLine("=== Multi-Stream Load Pipeline ===");
+    Console.WriteLine();
+
+    // --- Extract → Transform → Load pipeline ---
     var people = new List<Person>
     {
         new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
         new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
     };
 
-    // --- Load each person to its own stream ---
+    var extractor = new TestExtractor<Person>(people);
+    var transformer = new TestTransformer<Person>();
+
     var buffers = new Dictionary<string, MemoryStream>();
     var loader = new XmlMultiStreamLoader<Person>
     (
@@ -96,103 +175,85 @@ static async Task MultiStreamExample(ILoggerFactory loggerFactory)
             buffers[key] = ms;
             return ms;
         },
+        new XmlWriterSettings { Indent = true },
         loggerFactory.CreateLogger<XmlMultiStreamLoader<Person>>()
     );
 
-    await loader.LoadAsync(people.ToAsyncEnumerable());
-    Console.WriteLine($"Loaded {loader.CurrentItemCount} items to {buffers.Count} streams.");
+    await loader.LoadAsync(transformer.TransformAsync(extractor.ExtractAsync()));
 
-    // --- Extract from the streams ---
-    var streams = buffers.Values.Select(ms =>
+    Console.WriteLine($"Extracted {extractor.CurrentItemCount} items from memory.");
+    Console.WriteLine($"Transformed {transformer.CurrentItemCount} items.");
+    Console.WriteLine($"Loaded {loader.CurrentItemCount} items to {buffers.Count} XML streams.");
+    Console.WriteLine();
+
+    foreach (var (fileName, buffer) in buffers)
     {
-        var copy = new MemoryStream(ms.ToArray());
-        return (Stream)copy;
-    });
-
-    var extractor = new XmlMultiStreamExtractor<Person>
-    (
-        streams,
-        loggerFactory.CreateLogger<XmlMultiStreamExtractor<Person>>()
-    );
-
-    Console.WriteLine("Extracted items:");
-    await foreach (var person in extractor.ExtractAsync())
-    {
-        Console.WriteLine($"  {person.FirstName} {person.LastName}, age {person.Age}");
+        buffer.Position = 0;
+        using var streamReader = new StreamReader(buffer);
+        Console.WriteLine($"--- {fileName} ---");
+        Console.WriteLine(await streamReader.ReadToEndAsync());
+        Console.WriteLine();
     }
 }
 
 
 
-static async Task ProgressReportingExample(ILoggerFactory loggerFactory)
+/// <summary>
+/// Creates a MemoryStream containing sample XML with three Person elements.
+/// </summary>
+static MemoryStream CreateSampleXmlStream()
 {
-    Console.WriteLine("=== Progress Reporting Example ===");
-    Console.WriteLine();
-
-    var people = Enumerable.Range(1, 20).Select(i => new Person
-    {
-        FirstName = $"Person{i}",
-        LastName = $"Last{i}",
-        Age = 20 + i,
-    }).ToList();
+    var serializer = new XmlSerializer(typeof(Person));
+    var emptyNs = new XmlSerializerNamespaces(new[] { new XmlQualifiedName("", "") });
 
     var stream = new MemoryStream();
-    var loader = new XmlSingleStreamLoader<Person>
-    (
-        stream,
-        loggerFactory.CreateLogger<XmlSingleStreamLoader<Person>>()
-    );
-    loader.ReportingInterval = 100; // Report every 100ms
+    var settings = new XmlWriterSettings { Indent = true, CloseOutput = false };
+    using var writer = XmlWriter.Create(stream, settings);
 
-    var progress = new Progress<XmlReport>(report =>
-        Console.WriteLine($"  Progress: {report.CurrentItemCount} items loaded, {report.CurrentSkippedItemCount} skipped")
-    );
+    writer.WriteStartDocument();
+    writer.WriteStartElement("ArrayOfPerson");
 
-    await loader.LoadAsync(people.ToAsyncEnumerable(), progress);
-    Console.WriteLine($"Completed. Loaded {loader.CurrentItemCount} items.");
-}
-
-
-
-static async Task SkipAndMaxExample(ILoggerFactory loggerFactory)
-{
-    Console.WriteLine("=== Skip and Maximum Item Count Example ===");
-    Console.WriteLine();
-
-    // Create a large XML stream
-    var people = Enumerable.Range(1, 100).Select(i => new Person
+    foreach (var person in SamplePeople())
     {
-        FirstName = $"Person{i}",
-        LastName = $"Last{i}",
-        Age = 20 + (i % 50),
-    }).ToList();
+        serializer.Serialize(writer, person, emptyNs);
+    }
 
-    var stream = new MemoryStream();
-    var loader = new XmlSingleStreamLoader<Person>
-    (
-        stream,
-        new XmlWriterSettings { Indent = false },
-        loggerFactory.CreateLogger<XmlSingleStreamLoader<Person>>()
-    );
+    writer.WriteEndElement();
+    writer.WriteEndDocument();
+    writer.Flush();
 
-    await loader.LoadAsync(people.ToAsyncEnumerable());
-    Console.WriteLine($"Loaded {loader.CurrentItemCount} items to stream.");
-
-    // Now extract with skip and max
     stream.Position = 0;
-    var extractor = new XmlSingleStreamExtractor<Person>
-    (
-        stream,
-        loggerFactory.CreateLogger<XmlSingleStreamExtractor<Person>>()
-    );
-    extractor.SkipItemCount = 10;     // Skip first 10
-    extractor.MaximumItemCount = 5;   // Then take 5
+    return stream;
+}
 
-    Console.WriteLine("Extracting with SkipItemCount=10, MaximumItemCount=5:");
-    await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
+
+
+/// <summary>
+/// Creates a list of MemoryStreams, each containing a single Person as XML.
+/// </summary>
+static List<MemoryStream> CreateSampleMultiStreams()
+{
+    var serializer = new XmlSerializer(typeof(Person));
+    var emptyNs = new XmlSerializerNamespaces(new[] { new XmlQualifiedName("", "") });
+    var streams = new List<MemoryStream>();
+
+    foreach (var person in SamplePeople())
     {
-        Console.WriteLine($"  {person.FirstName} {person.LastName}");
+        var ms = new MemoryStream();
+        serializer.Serialize(ms, person, emptyNs);
+        ms.Position = 0;
+        streams.Add(ms);
     }
 
-    Console.WriteLine($"Extracted: {extractor.CurrentItemCount}, Skipped: {extractor.CurrentSkippedItemCount}");
+    return streams;
 }
+
+
+
+static List<Person> SamplePeople() =>
+    new()
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
+        new() { FirstName = "Carol", LastName = "White", Age = 35, Email = "carol@example.com" },
+    };

--- a/examples/Wolfgang.Etl.Xml.Examples/Wolfgang.Etl.Xml.Examples.csproj
+++ b/examples/Wolfgang.Etl.Xml.Examples/Wolfgang.Etl.Xml.Examples.csproj
@@ -15,7 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Etl.Xml/Wolfgang.Etl.Xml.csproj
+++ b/src/Wolfgang.Etl.Xml/Wolfgang.Etl.Xml.csproj
@@ -39,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.10.2" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.11.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/Wolfgang.Etl.Xml.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/Wolfgang.Etl.Xml.Tests.Unit.csproj
@@ -19,7 +19,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="!$(TargetFramework.StartsWith('netcoreapp')) AND !$(TargetFramework.StartsWith('net5.')) AND !$(TargetFramework.StartsWith('net6.')) AND !$(TargetFramework.StartsWith('net7.'))" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" Condition="$(TargetFramework.StartsWith('netcoreapp')) OR $(TargetFramework.StartsWith('net5.')) OR $(TargetFramework.StartsWith('net6.')) OR $(TargetFramework.StartsWith('net7.'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.5.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.5.0" />


### PR DESCRIPTION
## Summary
- Bump Wolfgang.Etl.Abstractions to 0.11.0 and TestKit/TestKit.Xunit to 0.5.0
- Update third-party dependencies (Meziantou 3.0.26, SonarAnalyzer 10.21, BenchmarkDotNet 0.15.8, Microsoft.Extensions 10.0.5, Test.Sdk 18.3.0 with conditional fallback)
- Replace README template placeholders with real Quick Start examples and feature descriptions
- Expand DocFX getting-started and introduction pages
- Rewrite examples project with full ETL pipeline demonstrations

## Test plan
- [ ] All 192 tests pass across all target frameworks
- [ ] Build succeeds with zero warnings
- [ ] DocFX site builds correctly
- [ ] NuGet package metadata is correct (version, license, icon, readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)