### PR TITLE
Fix: Drop netcoreapp3.1 test TFM — not available in CI

### DIFF
--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/Wolfgang.Etl.Xml.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/Wolfgang.Etl.Xml.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
@@ -19,8 +19,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="!$(TargetFramework.StartsWith('netcoreapp')) AND !$(TargetFramework.StartsWith('net5.')) AND !$(TargetFramework.StartsWith('net6.')) AND !$(TargetFramework.StartsWith('net7.'))" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" Condition="$(TargetFramework.StartsWith('netcoreapp')) OR $(TargetFramework.StartsWith('net5.')) OR $(TargetFramework.StartsWith('net6.')) OR $(TargetFramework.StartsWith('net7.'))" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="!$(TargetFramework.StartsWith('net5.')) AND !$(TargetFramework.StartsWith('net6.')) AND !$(TargetFramework.StartsWith('net7.'))" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" Condition="$(TargetFramework.StartsWith('net5.')) OR $(TargetFramework.StartsWith('net6.')) OR $(TargetFramework.StartsWith('net7.'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.5.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.5.0" />


### PR DESCRIPTION
## Summary
- Remove `netcoreapp3.1` from test project `TargetFrameworks` — the GitHub Actions runner does not have .NET Core 3.1 installed (EOL December 2022)
- Simplify `Microsoft.NET.Test.Sdk` version conditions to remove the now-unnecessary `netcoreapp` check

## Test plan
- [ ] CI passes for all remaining test TFMs (net462 through net10.0, excluding netcoreapp3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)