### PR TITLE
Sync cross-repo template fixes

### DIFF
--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -46,7 +46,9 @@ Ensure the following settings are enabled:
     - "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     - "Stage 3: macOS Tests (.NET 6.0-10.0)"
     - "Security Scan (DevSkim)"
-    - "Security Scan (CodeQL)"
+- ✅ **CodeQL code scanning enforcement** (via `code_scanning` ruleset type, not status checks)
+  - Blocks merging on High+ severity findings
+  - Automatically skips when no supported languages are detected
 - ✅ **Require branches to be up to date before merging**
 - ✅ **Require conversation resolution before merging**
 - ✅ **Do not allow bypassing the above settings** (recommended, even for admins)

--- a/scripts/Fix-BranchRuleset.ps1
+++ b/scripts/Fix-BranchRuleset.ps1
@@ -15,6 +15,9 @@
 .PARAMETER Force
     Skip the confirmation prompt and proceed automatically. Alias: -y
 
+.PARAMETER SkipSetup
+    Skip automatic invocation of Setup-BranchRuleset.ps1 after fixing.
+
 .EXAMPLE
     .\Fix-BranchRuleset.ps1
     Inspects and fixes rulesets for the current repository with interactive confirmation
@@ -22,6 +25,10 @@
 .EXAMPLE
     .\Fix-BranchRuleset.ps1 -Force
     Inspects and fixes rulesets without prompting for confirmation
+
+.EXAMPLE
+    .Fix-BranchRuleset.ps1 -Force -SkipSetup
+    Fixes rulesets non-interactively without recreating a fresh ruleset
 
 .EXAMPLE
     .\Fix-BranchRuleset.ps1 -y
@@ -43,7 +50,10 @@ param(
 
     [Parameter()]
     [Alias("y")]
-    [switch]$Force
+    [switch]$Force,
+
+    [Parameter()]
+    [switch]$SkipSetup
 )
 
 # Check if gh CLI is installed
@@ -173,7 +183,7 @@ foreach ($item in $plan) {
 Write-Host ""
 
 # Prompt for confirmation
-if ($Force) {
+if ($SkipSetup) {
     Write-Host "Auto-confirmed via -Force/-y flag." -ForegroundColor Green
 } else {
     $response = Read-Host "Proceed with these changes? (y/N)"

--- a/scripts/Fix-BranchRuleset.ps1
+++ b/scripts/Fix-BranchRuleset.ps1
@@ -27,12 +27,8 @@
     Inspects and fixes rulesets without prompting for confirmation
 
 .EXAMPLE
-    .Fix-BranchRuleset.ps1 -Force -SkipSetup
+    .\Fix-BranchRuleset.ps1 -Force -SkipSetup
     Fixes rulesets non-interactively without recreating a fresh ruleset
-
-.EXAMPLE
-    .\Fix-BranchRuleset.ps1 -y
-    Same as -Force, using the short alias
 
 .EXAMPLE
     .\Fix-BranchRuleset.ps1 -Repository "Chris-Wolfgang/my-repo"
@@ -183,8 +179,8 @@ foreach ($item in $plan) {
 Write-Host ""
 
 # Prompt for confirmation
-if ($SkipSetup) {
-    Write-Host "Auto-confirmed via -Force/-y flag." -ForegroundColor Green
+if ($Force) {
+    Write-Host "Auto-confirmed via -Force flag." -ForegroundColor Green
 } else {
     $response = Read-Host "Proceed with these changes? (y/N)"
     if ($response -ne 'y' -and $response -ne 'Y') {
@@ -260,7 +256,11 @@ if ($errors -gt 0) {
 
     # Invoke Setup-BranchRuleset.ps1 to create a fresh ruleset
     $setupScript = Join-Path $PSScriptRoot "Setup-BranchRuleset.ps1"
-    if (Test-Path $setupScript) {
+    if ($SkipSetup) {
+        Write-Host "Skipping Setup-BranchRuleset.ps1 (-SkipSetup specified)." -ForegroundColor Yellow
+        Write-Host "Run it manually to create a fresh ruleset:" -ForegroundColor Cyan
+        Write-Host "  pwsh -File `"$setupScript`" -Repository $Repository" -ForegroundColor Cyan
+    } elseif (Test-Path $setupScript) {
         Write-Host "Running Setup-BranchRuleset.ps1 to create a fresh ruleset..." -ForegroundColor Cyan
         Write-Host ""
         & $setupScript -Repository $Repository


### PR DESCRIPTION
## Summary

- Update RELEASE-WORKFLOW-SETUP.md: CodeQL uses code_scanning ruleset type
- Add -SkipSetup flag to Fix-BranchRuleset.ps1

## Test plan
- [ ] Verify Fix-BranchRuleset.ps1 flags work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)