### PR TITLE
Add (stream, logger) constructors to all four XML classes

### DIFF
--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamExtractor.cs
@@ -68,6 +68,28 @@ public sealed class XmlMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, Xm
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlMultiStreamExtractor{TRecord}"/> class
+    /// with a logger.
+    /// </summary>
+    /// <param name="streams">An enumerable of streams, each containing a single XML document.</param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="streams"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public XmlMultiStreamExtractor
+    (
+        IEnumerable<Stream> streams,
+        ILogger<XmlMultiStreamExtractor<TRecord>> logger
+    )
+    {
+        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _readerSettings = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlMultiStreamExtractor{TRecord}"/> class
     /// with custom reader settings.
     /// </summary>
     /// <param name="streams">An enumerable of streams, each containing a single XML document.</param>

--- a/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlMultiStreamLoader.cs
@@ -65,6 +65,31 @@ public sealed class XmlMultiStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepor
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlMultiStreamLoader{TRecord}"/> class
+    /// with a logger.
+    /// </summary>
+    /// <param name="streamFactory">
+    /// A factory function that receives the item to be written and returns a <see cref="Stream"/> to write it to.
+    /// The loader will dispose the stream after writing.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="streamFactory"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public XmlMultiStreamLoader
+    (
+        Func<TRecord, Stream> streamFactory,
+        ILogger<XmlMultiStreamLoader<TRecord>> logger
+    )
+    {
+        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _writerSettings = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlMultiStreamLoader{TRecord}"/> class
     /// with custom writer settings.
     /// </summary>
     /// <param name="streamFactory">

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamExtractor.cs
@@ -87,6 +87,28 @@ public sealed class XmlSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, X
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlSingleStreamExtractor{TRecord}"/> class
+    /// with a logger.
+    /// </summary>
+    /// <param name="stream">The stream containing XML data to read from.</param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public XmlSingleStreamExtractor
+    (
+        Stream stream,
+        ILogger<XmlSingleStreamExtractor<TRecord>> logger
+    )
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _readerSettings = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlSingleStreamExtractor{TRecord}"/> class
     /// with custom reader settings.
     /// </summary>
     /// <param name="stream">The stream containing XML data to read from.</param>

--- a/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Xml/XmlSingleStreamLoader.cs
@@ -95,6 +95,30 @@ public sealed class XmlSingleStreamLoader<TRecord> : LoaderBase<TRecord, XmlRepo
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlSingleStreamLoader{TRecord}"/> class
+    /// with a logger.
+    /// </summary>
+    /// <param name="stream">The stream to write XML data to.</param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public XmlSingleStreamLoader
+    (
+        Stream stream,
+        ILogger<XmlSingleStreamLoader<TRecord>> logger
+    )
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _writerSettings = null;
+
+        _rootElementName = "ArrayOf" + typeof(TRecord).Name;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlSingleStreamLoader{TRecord}"/> class
     /// with custom writer settings.
     /// </summary>
     /// <param name="stream">The stream to write XML data to.</param>

--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlMultiStreamExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlMultiStreamExtractorTests.cs
@@ -139,6 +139,21 @@ public class XmlMultiStreamExtractorTests
 
 
     [Fact]
+    public void Constructor_Streams_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new XmlMultiStreamExtractor<PersonRecord>
+            (
+                Array.Empty<Stream>(),
+                logger: null!
+            )
+        );
+    }
+
+
+
+    [Fact]
     public void Constructor_with_settings_when_streams_is_null_throws_ArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>

--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlMultiStreamLoaderTests.cs
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlMultiStreamLoaderTests.cs
@@ -232,6 +232,21 @@ public class XmlMultiStreamLoaderTests
 
 
     [Fact]
+    public void Constructor_StreamFactory_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new XmlMultiStreamLoader<PersonRecord>
+            (
+                _ => new MemoryStream(),
+                logger: null!
+            )
+        );
+    }
+
+
+
+    [Fact]
     public void Constructor_with_settings_when_settings_is_null_throws_ArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>

--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlSingleStreamExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlSingleStreamExtractorTests.cs
@@ -229,6 +229,21 @@ public class XmlSingleStreamExtractorTests
 
 
     [Fact]
+    public void Constructor_Stream_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new XmlSingleStreamExtractor<PersonRecord>
+            (
+                new MemoryStream(),
+                logger: null!
+            )
+        );
+    }
+
+
+
+    [Fact]
     public void Constructor_with_settings_when_settings_is_null_throws_ArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>

--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlSingleStreamLoaderTests.cs
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/XmlSingleStreamLoaderTests.cs
@@ -365,6 +365,21 @@ public class XmlSingleStreamLoaderTests
 
 
     [Fact]
+    public void Constructor_Stream_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new XmlSingleStreamLoader<PersonRecord>
+            (
+                new MemoryStream(),
+                logger: null!
+            )
+        );
+    }
+
+
+
+    [Fact]
     public void Constructor_with_settings_when_settings_is_null_throws_ArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>


### PR DESCRIPTION
## Summary

- Adds a 2-parameter `(stream, logger)` constructor to all four XML classes: `XmlSingleStreamExtractor`, `XmlSingleStreamLoader`, `XmlMultiStreamExtractor`, `XmlMultiStreamLoader`
- Provides a convenient overload when a logger is needed but default settings are sufficient
- Adds a null-logger guard test for each new constructor

## Test plan
- [ ] Verify CI passes
- [ ] `Constructor_Stream_Logger_when_logger_is_null_throws_ArgumentNullException` passes for single-stream classes
- [ ] `Constructor_Streams_Logger_when_logger_is_null_throws_ArgumentNullException` passes for multi-stream extractor
- [ ] `Constructor_StreamFactory_Logger_when_logger_is_null_throws_ArgumentNullException` passes for multi-stream loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)