### PR TITLE
Bump version to 0.2.0 and upgrade Wolfgang.Etl dependencies

### DIFF
--- a/src/Wolfgang.Etl.Xml/Wolfgang.Etl.Xml.csproj
+++ b/src/Wolfgang.Etl.Xml/Wolfgang.Etl.Xml.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.12.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.13.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
   </ItemGroup>

--- a/tests/Wolfgang.Etl.Xml.Tests.Unit/Wolfgang.Etl.Xml.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Xml.Tests.Unit/Wolfgang.Etl.Xml.Tests.Unit.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
+    <Version>0.2.0</Version>
     <IsPackable>false</IsPackable>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
@@ -18,12 +19,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="!$(TargetFramework.StartsWith('net5.')) AND !$(TargetFramework.StartsWith('net6.')) AND !$(TargetFramework.StartsWith('net7.')) AND !$(TargetFramework.StartsWith('netcoreapp'))" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="$(TargetFramework.StartsWith('net5.')) OR $(TargetFramework.StartsWith('net6.')) OR $(TargetFramework.StartsWith('net7.')) OR $(TargetFramework.StartsWith('netcoreapp'))" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.6.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.5.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.7.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Bumps `Wolfgang.Etl.Xml` from 0.1.0 to 0.2.0.
- Adds matching `<Version>0.2.0</Version>` to the test project.
- Upgrades `Wolfgang.Etl.Abstractions` PackageReference: 0.12.0 → 0.13.0.
- Upgrades `Wolfgang.Etl.TestKit` PackageReference: 0.6.0 → 0.7.0.
- Upgrades `Wolfgang.Etl.TestKit.Xunit` PackageReference: 0.5.0 → 0.6.0.
- Bumps test project `Microsoft.Bcl.AsyncInterfaces` 10.0.6 → 10.0.7 and `System.Linq.Async` 7.0.0 → 7.0.1 to satisfy TestKit 0.7.0's transitive minimums (mirrors fix from ETL-Json#51 to avoid NU1605).

## Test plan
- [ ] CI builds and tests pass on all target frameworks
- [ ] Restore picks up Abstractions 0.13.0, TestKit 0.7.0, TestKit.Xunit 0.6.0 from NuGet