### PR TITLE
docfx.json: wire favicon assets (was silently skipped in earlier fanout)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -33,11 +33,13 @@
       {
         "files": [
           "logo.svg",
+          "apple-touch-icon.png",
+          "favicon.ico",
+          "favicon.svg",
           "images/**"
         ]
       }
     ],
-
     "output": "_site",
     "template": [
       "default",
@@ -47,6 +49,7 @@
       "_appName": "Wolfgang.Etl.Xml",
       "_appTitle": "Wolfgang.Etl.Xml Documentation",
       "_appLogoPath": "logo.svg",
+      "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX",
       "_disableSidebar": false,
@@ -58,4 +61,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Summary

The earlier favicon fanout (feature/docs-favicon) added `docfx_project/favicon.svg|.ico` + `apple-touch-icon.png` but its docfx.json patch silently failed on most repos. The files are on main, DocFX has no idea about them, and the rendered site still uses the default DocFX favicon instead of the W.

This PR adds the wiring:

- `build.resource[0].files` — adds `favicon.svg`, `favicon.ico`, `apple-touch-icon.png` so the assets are copied to `_site/`
- `build.globalMetadata._appFaviconPath` — set to `favicon.svg`, the DocFX modern template's native favicon hook (emits `<link rel="icon" href="favicon.svg">`)

No other changes to docfx.json. Built with the same Node.js JSON-aware transform used for the canonical ruleset fixes, so no comment/key-order corruption.